### PR TITLE
Use ESLint's `getConfigForFile` for configuration loading

### DIFF
--- a/.npm/plugin/eslint/npm-shrinkwrap.json
+++ b/.npm/plugin/eslint/npm-shrinkwrap.json
@@ -1,495 +1,930 @@
 {
   "dependencies": {
     "eslint": {
-      "version": "1.1.0",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.5.3.tgz",
+      "from": "eslint@2.5.3",
       "dependencies": {
         "chalk": {
-          "version": "1.1.0",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.1.0"
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "from": "ansi-styles@>=2.2.1 <3.0.0"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0"
             },
             "has-ansi": {
               "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "2.0.0"
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0"
                 }
               }
             },
             "strip-ansi": {
-              "version": "3.0.0",
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "2.0.0"
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0"
                 }
               }
             },
             "supports-color": {
-              "version": "2.0.0"
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "from": "supports-color@>=2.0.0 <3.0.0"
             }
           }
         },
         "concat-stream": {
-          "version": "1.5.0",
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+          "from": "concat-stream@>=1.4.6 <2.0.0",
           "dependencies": {
             "inherits": {
-              "version": "2.0.1"
-            },
-            "typedarray": {
-              "version": "0.0.6"
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@>=2.0.1 <2.1.0"
             },
             "readable-stream": {
-              "version": "2.0.2",
+              "version": "2.0.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+              "from": "readable-stream@>=2.0.0 <2.1.0",
               "dependencies": {
                 "core-util-is": {
-                  "version": "1.0.1"
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0"
                 },
                 "isarray": {
-                  "version": "0.0.1"
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "from": "isarray@>=1.0.0 <1.1.0"
                 },
                 "process-nextick-args": {
-                  "version": "1.0.2"
+                  "version": "1.0.6",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0"
                 },
                 "string_decoder": {
-                  "version": "0.10.31"
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0"
                 },
                 "util-deprecate": {
-                  "version": "1.0.1"
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0"
                 }
               }
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+              "from": "typedarray@>=0.0.5 <0.1.0"
             }
           }
         },
         "debug": {
           "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "from": "debug@>=2.1.1 <3.0.0",
           "dependencies": {
             "ms": {
-              "version": "0.7.1"
+              "version": "0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "from": "ms@0.7.1"
             }
           }
         },
         "doctrine": {
-          "version": "0.6.4",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.2.0.tgz",
+          "from": "doctrine@>=1.2.0 <2.0.0",
           "dependencies": {
             "esutils": {
-              "version": "1.1.6"
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+              "from": "esutils@>=1.1.6 <2.0.0"
             },
             "isarray": {
-              "version": "0.0.1"
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "from": "isarray@>=1.0.0 <2.0.0"
             }
           }
         },
-        "escape-string-regexp": {
-          "version": "1.0.3"
+        "es6-map": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz",
+          "from": "es6-map@>=0.1.3 <0.2.0",
+          "dependencies": {
+            "d": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+              "from": "d@>=0.1.1 <0.2.0"
+            },
+            "es5-ext": {
+              "version": "0.10.11",
+              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
+              "from": "es5-ext@>=0.10.8 <0.11.0"
+            },
+            "es6-iterator": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
+              "from": "es6-iterator@>=2.0.0 <3.0.0"
+            },
+            "es6-set": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
+              "from": "es6-set@>=0.1.3 <0.2.0"
+            },
+            "es6-symbol": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
+              "from": "es6-symbol@>=3.0.1 <3.1.0"
+            },
+            "event-emitter": {
+              "version": "0.3.4",
+              "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
+              "from": "event-emitter@>=0.3.4 <0.4.0"
+            }
+          }
         },
         "escope": {
-          "version": "3.2.0",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+          "from": "escope@>=3.6.0 <4.0.0",
           "dependencies": {
-            "es6-map": {
-              "version": "0.1.1",
-              "dependencies": {
-                "d": {
-                  "version": "0.1.1"
-                },
-                "es5-ext": {
-                  "version": "0.10.7",
-                  "dependencies": {
-                    "es6-symbol": {
-                      "version": "2.0.1"
-                    }
-                  }
-                },
-                "es6-iterator": {
-                  "version": "0.1.3",
-                  "dependencies": {
-                    "es6-symbol": {
-                      "version": "2.0.1"
-                    }
-                  }
-                },
-                "es6-set": {
-                  "version": "0.1.1"
-                },
-                "es6-symbol": {
-                  "version": "0.1.1"
-                },
-                "event-emitter": {
-                  "version": "0.3.3"
-                }
-              }
-            },
             "es6-weak-map": {
-              "version": "0.1.4",
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
+              "from": "es6-weak-map@>=2.0.1 <3.0.0",
               "dependencies": {
                 "d": {
-                  "version": "0.1.1"
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                  "from": "d@>=0.1.1 <0.2.0"
                 },
                 "es5-ext": {
-                  "version": "0.10.7"
+                  "version": "0.10.11",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
+                  "from": "es5-ext@>=0.10.8 <0.11.0"
                 },
                 "es6-iterator": {
-                  "version": "0.1.3"
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
+                  "from": "es6-iterator@>=2.0.0 <3.0.0"
                 },
                 "es6-symbol": {
-                  "version": "2.0.1"
+                  "version": "3.0.2",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
+                  "from": "es6-symbol@>=3.0.0 <4.0.0"
                 }
               }
             },
             "esrecurse": {
-              "version": "3.1.1"
-            },
-            "estraverse": {
-              "version": "3.1.0"
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+              "from": "esrecurse@>=4.1.0 <5.0.0",
+              "dependencies": {
+                "estraverse": {
+                  "version": "4.1.1",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
+                  "from": "estraverse@>=4.1.0 <4.2.0"
+                },
+                "object-assign": {
+                  "version": "4.0.1",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+                  "from": "object-assign@>=4.0.1 <5.0.0"
+                }
+              }
             }
           }
         },
         "espree": {
-          "version": "2.2.4"
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-3.1.3.tgz",
+          "from": "espree@3.1.3",
+          "dependencies": {
+            "acorn": {
+              "version": "3.0.4",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.0.4.tgz",
+              "from": "acorn@>=3.0.4 <4.0.0"
+            },
+            "acorn-jsx": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-2.0.1.tgz",
+              "from": "acorn-jsx@>=2.0.1 <3.0.0",
+              "dependencies": {
+                "acorn": {
+                  "version": "2.7.0",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+                  "from": "acorn@>=2.0.1 <3.0.0"
+                }
+              }
+            }
+          }
         },
         "estraverse": {
-          "version": "4.1.0"
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+          "from": "estraverse@>=4.2.0 <5.0.0"
         },
-        "estraverse-fb": {
-          "version": "1.3.1"
+        "esutils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "from": "esutils@>=2.0.2 <3.0.0"
         },
-        "globals": {
-          "version": "8.3.0"
-        },
-        "inquirer": {
-          "version": "0.9.0",
+        "file-entry-cache": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
+          "from": "file-entry-cache@>=1.1.1 <2.0.0",
           "dependencies": {
-            "ansi-regex": {
-              "version": "2.0.0"
-            },
-            "cli-width": {
-              "version": "1.0.1"
-            },
-            "figures": {
-              "version": "1.3.5"
-            },
-            "lodash": {
-              "version": "3.10.1"
-            },
-            "readline2": {
-              "version": "0.1.1",
+            "flat-cache": {
+              "version": "1.0.10",
+              "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz",
+              "from": "flat-cache@>=1.0.9 <2.0.0",
               "dependencies": {
-                "mute-stream": {
-                  "version": "0.0.4"
-                },
-                "strip-ansi": {
-                  "version": "2.0.1",
+                "del": {
+                  "version": "2.2.0",
+                  "resolved": "https://registry.npmjs.org/del/-/del-2.2.0.tgz",
+                  "from": "del@>=2.0.2 <3.0.0",
                   "dependencies": {
-                    "ansi-regex": {
-                      "version": "1.1.1"
+                    "globby": {
+                      "version": "4.0.0",
+                      "resolved": "https://registry.npmjs.org/globby/-/globby-4.0.0.tgz",
+                      "from": "globby@>=4.0.0 <5.0.0",
+                      "dependencies": {
+                        "array-union": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+                          "from": "array-union@>=1.0.1 <2.0.0",
+                          "dependencies": {
+                            "array-uniq": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+                              "from": "array-uniq@>=1.0.1 <2.0.0"
+                            }
+                          }
+                        },
+                        "arrify": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                          "from": "arrify@>=1.0.0 <2.0.0"
+                        },
+                        "glob": {
+                          "version": "6.0.4",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                          "from": "glob@>=6.0.1 <7.0.0",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "from": "inflight@>=1.0.4 <2.0.0",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "from": "wrappy@>=1.0.0 <2.0.0"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "from": "inherits@>=2.0.0 <3.0.0"
+                            },
+                            "minimatch": {
+                              "version": "3.0.0",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.3",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.3.0",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                      "from": "balanced-match@>=0.3.0 <0.4.0"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "from": "concat-map@0.0.1"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "from": "once@>=1.3.0 <2.0.0",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "from": "wrappy@>=1.0.0 <2.0.0"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "is-path-cwd": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+                      "from": "is-path-cwd@>=1.0.0 <2.0.0"
+                    },
+                    "is-path-in-cwd": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+                      "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "is-path-inside": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+                          "from": "is-path-inside@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    },
+                    "pify": {
+                      "version": "2.3.0",
+                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                      "from": "pify@>=2.0.0 <3.0.0"
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4",
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                          "from": "pinkie@>=2.0.0 <3.0.0"
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.5.2",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                      "from": "rimraf@>=2.2.8 <3.0.0"
                     }
                   }
+                },
+                "graceful-fs": {
+                  "version": "4.1.3",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
+                  "from": "graceful-fs@>=4.1.2 <5.0.0"
+                },
+                "read-json-sync": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.1.tgz",
+                  "from": "read-json-sync@>=1.1.0 <2.0.0"
+                },
+                "write": {
+                  "version": "0.2.1",
+                  "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+                  "from": "write@>=0.2.1 <0.3.0"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+              "from": "object-assign@>=4.0.1 <5.0.0"
+            }
+          }
+        },
+        "glob": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+          "from": "glob@>=7.0.3 <8.0.0",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@>=2.0.0 <3.0.0"
+            },
+            "minimatch": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                      "from": "balanced-match@>=0.3.0 <0.4.0"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.3",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "from": "once@>=1.3.0 <2.0.0",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0"
+                }
+              }
+            }
+          }
+        },
+        "globals": {
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.2.0.tgz",
+          "from": "globals@>=9.2.0 <10.0.0"
+        },
+        "ignore": {
+          "version": "3.0.13",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.0.13.tgz",
+          "from": "ignore@>=3.0.10 <4.0.0"
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "from": "imurmurhash@>=0.1.4 <0.2.0"
+        },
+        "inquirer": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "from": "inquirer@>=0.12.0 <0.13.0",
+          "dependencies": {
+            "ansi-escapes": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.3.0.tgz",
+              "from": "ansi-escapes@>=1.1.0 <2.0.0"
+            },
+            "ansi-regex": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+              "from": "ansi-regex@>=2.0.0 <3.0.0"
+            },
+            "cli-cursor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+              "from": "cli-cursor@>=1.0.1 <2.0.0",
+              "dependencies": {
+                "restore-cursor": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+                  "from": "restore-cursor@>=1.0.1 <2.0.0",
+                  "dependencies": {
+                    "exit-hook": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+                      "from": "exit-hook@>=1.0.0 <2.0.0"
+                    },
+                    "onetime": {
+                      "version": "1.1.0",
+                      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+                      "from": "onetime@>=1.0.0 <2.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "cli-width": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+              "from": "cli-width@>=2.0.0 <3.0.0"
+            },
+            "figures": {
+              "version": "1.5.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.5.0.tgz",
+              "from": "figures@>=1.3.5 <2.0.0"
+            },
+            "readline2": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+              "from": "readline2@>=1.0.1 <2.0.0",
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                  "from": "code-point-at@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "mute-stream": {
+                  "version": "0.0.5",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+                  "from": "mute-stream@0.0.5"
                 }
               }
             },
             "run-async": {
               "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+              "from": "run-async@>=0.1.0 <0.2.0",
               "dependencies": {
                 "once": {
-                  "version": "1.3.2",
+                  "version": "1.3.3",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1"
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0"
                     }
                   }
                 }
               }
             },
             "rx-lite": {
-              "version": "2.5.2"
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+              "from": "rx-lite@>=3.1.2 <4.0.0"
+            },
+            "string-width": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
+              "from": "string-width@>=1.0.1 <2.0.0",
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                  "from": "code-point-at@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0"
+                    }
+                  }
+                }
+              }
             },
             "strip-ansi": {
-              "version": "3.0.0"
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "from": "strip-ansi@>=3.0.0 <4.0.0"
             },
             "through": {
-              "version": "2.3.8"
+              "version": "2.3.8",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "from": "through@>=2.3.6 <3.0.0"
             }
           }
         },
         "is-my-json-valid": {
-          "version": "2.12.1",
+          "version": "2.13.1",
+          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+          "from": "is-my-json-valid@>=2.10.0 <3.0.0",
           "dependencies": {
             "generate-function": {
-              "version": "2.0.0"
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+              "from": "generate-function@>=2.0.0 <3.0.0"
             },
             "generate-object-property": {
               "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+              "from": "generate-object-property@>=1.1.0 <2.0.0",
               "dependencies": {
                 "is-property": {
-                  "version": "1.0.2"
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                  "from": "is-property@>=1.0.0 <2.0.0"
                 }
               }
             },
             "jsonpointer": {
-              "version": "1.1.0"
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+              "from": "jsonpointer@2.0.0"
             },
             "xtend": {
-              "version": "4.0.0"
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "from": "xtend@>=4.0.0 <5.0.0"
+            }
+          }
+        },
+        "is-resolvable": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+          "from": "is-resolvable@>=1.0.0 <2.0.0",
+          "dependencies": {
+            "tryit": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz",
+              "from": "tryit@>=1.0.1 <2.0.0"
             }
           }
         },
         "js-yaml": {
-          "version": "3.3.1",
+          "version": "3.5.5",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
+          "from": "js-yaml@>=3.5.1 <4.0.0",
           "dependencies": {
             "argparse": {
-              "version": "1.0.2",
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
+              "from": "argparse@>=1.0.2 <2.0.0",
               "dependencies": {
-                "lodash": {
-                  "version": "3.10.1"
-                },
                 "sprintf-js": {
-                  "version": "1.0.3"
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                  "from": "sprintf-js@>=1.0.2 <1.1.0"
                 }
               }
             },
             "esprima": {
-              "version": "2.2.0"
+              "version": "2.7.2",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
+              "from": "esprima@>=2.6.0 <3.0.0"
             }
           }
         },
-        "lodash.clonedeep": {
-          "version": "3.0.2",
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "from": "json-stable-stringify@>=1.0.0 <2.0.0",
           "dependencies": {
-            "lodash._baseclone": {
-              "version": "3.3.0",
-              "dependencies": {
-                "lodash._arraycopy": {
-                  "version": "3.0.0"
-                },
-                "lodash._arrayeach": {
-                  "version": "3.0.0"
-                },
-                "lodash._baseassign": {
-                  "version": "3.2.0",
-                  "dependencies": {
-                    "lodash._basecopy": {
-                      "version": "3.0.1"
-                    }
-                  }
-                },
-                "lodash._basefor": {
-                  "version": "3.0.2"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4"
-                },
-                "lodash.keys": {
-                  "version": "3.1.2",
-                  "dependencies": {
-                    "lodash._getnative": {
-                      "version": "3.9.1"
-                    },
-                    "lodash.isarguments": {
-                      "version": "3.0.4"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash._bindcallback": {
-              "version": "3.0.1"
+            "jsonify": {
+              "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+              "from": "jsonify@>=0.0.0 <0.1.0"
             }
           }
         },
-        "lodash.merge": {
-          "version": "3.3.2",
-          "dependencies": {
-            "lodash._arraycopy": {
-              "version": "3.0.0"
-            },
-            "lodash._arrayeach": {
-              "version": "3.0.0"
-            },
-            "lodash._createassigner": {
-              "version": "3.1.1",
-              "dependencies": {
-                "lodash._bindcallback": {
-                  "version": "3.0.1"
-                },
-                "lodash._isiterateecall": {
-                  "version": "3.0.9"
-                },
-                "lodash.restparam": {
-                  "version": "3.6.1"
-                }
-              }
-            },
-            "lodash._getnative": {
-              "version": "3.9.1"
-            },
-            "lodash.isarguments": {
-              "version": "3.0.4"
-            },
-            "lodash.isarray": {
-              "version": "3.0.4"
-            },
-            "lodash.isplainobject": {
-              "version": "3.2.0",
-              "dependencies": {
-                "lodash._basefor": {
-                  "version": "3.0.2"
-                }
-              }
-            },
-            "lodash.istypedarray": {
-              "version": "3.0.2"
-            },
-            "lodash.keys": {
-              "version": "3.1.2"
-            },
-            "lodash.keysin": {
-              "version": "3.0.8"
-            },
-            "lodash.toplainobject": {
-              "version": "3.0.0",
-              "dependencies": {
-                "lodash._basecopy": {
-                  "version": "3.0.1"
-                }
-              }
-            }
-          }
-        },
-        "lodash.omit": {
-          "version": "3.1.0",
-          "dependencies": {
-            "lodash._arraymap": {
-              "version": "3.0.0"
-            },
-            "lodash._basedifference": {
-              "version": "3.0.3",
-              "dependencies": {
-                "lodash._baseindexof": {
-                  "version": "3.1.0"
-                },
-                "lodash._cacheindexof": {
-                  "version": "3.0.2"
-                },
-                "lodash._createcache": {
-                  "version": "3.1.2",
-                  "dependencies": {
-                    "lodash._getnative": {
-                      "version": "3.9.1"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash._baseflatten": {
-              "version": "3.1.4",
-              "dependencies": {
-                "lodash.isarguments": {
-                  "version": "3.0.4"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4"
-                }
-              }
-            },
-            "lodash._bindcallback": {
-              "version": "3.0.1"
-            },
-            "lodash._pickbyarray": {
-              "version": "3.0.2"
-            },
-            "lodash._pickbycallback": {
-              "version": "3.0.0",
-              "dependencies": {
-                "lodash._basefor": {
-                  "version": "3.0.2"
-                }
-              }
-            },
-            "lodash.keysin": {
-              "version": "3.0.8",
-              "dependencies": {
-                "lodash.isarguments": {
-                  "version": "3.0.4"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4"
-                }
-              }
-            },
-            "lodash.restparam": {
-              "version": "3.6.1"
-            }
-          }
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.0",
-              "dependencies": {
-                "balanced-match": {
-                  "version": "0.2.0"
-                },
-                "concat-map": {
-                  "version": "0.0.1"
-                }
-              }
-            }
-          }
+        "lodash": {
+          "version": "4.6.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.6.1.tgz",
+          "from": "lodash@>=4.0.0 <5.0.0"
         },
         "mkdirp": {
           "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
           "dependencies": {
             "minimist": {
-              "version": "0.0.8"
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8"
             }
           }
         },
-        "object-assign": {
-          "version": "2.1.1"
-        },
         "optionator": {
-          "version": "0.5.0",
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
+          "from": "optionator@>=0.8.1 <0.9.0",
           "dependencies": {
-            "prelude-ls": {
-              "version": "1.1.2"
-            },
             "deep-is": {
-              "version": "0.1.3"
-            },
-            "wordwrap": {
-              "version": "0.0.3"
-            },
-            "type-check": {
-              "version": "0.3.1"
-            },
-            "levn": {
-              "version": "0.2.5"
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+              "from": "deep-is@>=0.1.3 <0.2.0"
             },
             "fast-levenshtein": {
-              "version": "1.0.7"
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz",
+              "from": "fast-levenshtein@>=1.1.0 <2.0.0"
+            },
+            "levn": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+              "from": "levn@>=0.3.0 <0.4.0"
+            },
+            "prelude-ls": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+              "from": "prelude-ls@>=1.1.2 <1.2.0"
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+              "from": "type-check@>=0.3.2 <0.4.0"
+            },
+            "wordwrap": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+              "from": "wordwrap@>=1.0.0 <1.1.0"
             }
           }
         },
         "path-is-absolute": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+          "from": "path-is-absolute@>=1.0.0 <2.0.0"
         },
         "path-is-inside": {
-          "version": "1.0.1"
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
+          "from": "path-is-inside@>=1.0.1 <2.0.0"
+        },
+        "pluralize": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+          "from": "pluralize@>=1.2.1 <2.0.0"
+        },
+        "progress": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+          "from": "progress@>=1.1.8 <2.0.0"
+        },
+        "require-uncached": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.2.tgz",
+          "from": "require-uncached@>=1.0.2 <2.0.0",
+          "dependencies": {
+            "caller-path": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+              "from": "caller-path@>=0.1.0 <0.2.0",
+              "dependencies": {
+                "callsites": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+                  "from": "callsites@>=0.2.0 <0.3.0"
+                }
+              }
+            },
+            "resolve-from": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+              "from": "resolve-from@>=1.0.0 <2.0.0"
+            }
+          }
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "from": "resolve@>=1.1.6 <2.0.0"
+        },
+        "shelljs": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.0.tgz",
+          "from": "shelljs@>=0.6.0 <0.7.0"
+        },
+        "table": {
+          "version": "3.7.8",
+          "resolved": "https://registry.npmjs.org/table/-/table-3.7.8.tgz",
+          "from": "table@>=3.7.8 <4.0.0",
+          "dependencies": {
+            "bluebird": {
+              "version": "3.3.4",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.4.tgz",
+              "from": "bluebird@>=3.1.1 <4.0.0"
+            },
+            "slice-ansi": {
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+              "from": "slice-ansi@0.0.4"
+            },
+            "string-width": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
+              "from": "string-width@>=1.0.1 <2.0.0",
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                  "from": "code-point-at@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0"
+                }
+              }
+            },
+            "tv4": {
+              "version": "1.2.7",
+              "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz",
+              "from": "tv4@>=1.2.7 <2.0.0"
+            },
+            "xregexp": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.1.0.tgz",
+              "from": "xregexp@>=3.0.0 <4.0.0"
+            }
+          }
         },
         "text-table": {
-          "version": "0.2.0"
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "from": "text-table@>=0.2.0 <0.3.0"
         },
         "user-home": {
-          "version": "1.1.1"
-        },
-        "xml-escape": {
-          "version": "1.0.0"
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+          "from": "user-home@>=2.0.0 <3.0.0",
+          "dependencies": {
+            "os-homedir": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+              "from": "os-homedir@>=1.0.0 <2.0.0"
+            }
+          }
         }
       }
     },
     "strip-json-comments": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,23 @@ $ meteor add dburles:eslint
 
 Add an `.eslintrc` file to your project root. Here's a slightly modifed version of the Meteor configuration https://gist.github.com/dburles/a2f7ea77189b268b660d
 
+### Default `.eslintrc`
+
+The following is what gets overwritten by the `.eslintrc`:
+
+```json
+{
+  "env": {
+    "meteor": true,
+    "browser": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module"
+  }
+}
+```
+
 ### License
 
 MIT

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'dburles:eslint',
-  version: '1.0.1',
+  version: '1.0.2',
   summary: 'The pluggable linting utility for JavaScript and JSX.',
   documentation: 'README.md',
   git: 'https://github.com/dburles/meteor-eslint.git'
@@ -12,7 +12,7 @@ Package.registerBuildPlugin({
     'plugin/eslint.js'
   ],
   npmDependencies: {
-    "eslint": "1.1.0",
+    "eslint": "2.5.3",
     "strip-json-comments": "1.0.4"
   }
 });

--- a/plugin/eslint.js
+++ b/plugin/eslint.js
@@ -15,23 +15,9 @@ var DEFAULT_CONFIG = JSON.stringify({
     meteor: true,
     browser: true
   },
-  ecmaFeatures: {
-    arrowFunctions: true,
-    blockBindings: true,
-    classes: true,
-    defaultParams: true,
-    destructuring: true,
-    forOf: true,
-    generators: false,
-    modules: true,
-    objectLiteralComputedProperties: true,
-    objectLiteralDuplicateProperties: false,
-    objectLiteralShorthandMethods: true,
-    objectLiteralShorthandProperties: true,
-    spread: true,
-    superInFunctions: true,
-    templateStrings: true,
-    jsx: true
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: "module"
   }
 });
 


### PR DESCRIPTION
Using [`getConfigForFile`](http://eslint.org/docs/developer-guide/nodejs-api#getconfigforfile) ensures that parameters such as `extends` are supported and loads the contents of those extensions. For example, it allows you to use [Airbnb's preset](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb) like this:

``` json
{
  "extends": "airbnb"
}
```

It is possible that this could have been done better, I didn't really have time to be super thorough.

The ESLint version that is used is also changed to the latest `2.5.3`.

Not really sure what happened in [`.npm/plugin/eslint/npm-shrinkwrap.json`](.npm/plugin/eslint/npm-shrinkwrap.json). Perhaps it might be some Meteor 1.3 magic going on?
